### PR TITLE
Add SSH certificate authentication method for connection via Bastion

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -155,11 +155,13 @@ func (c *Communicator) Connect(o terraform.UIOutput) (err error) {
 					"  User: %s\n"+
 					"  Password: %t\n"+
 					"  Private key: %t\n"+
+					"  Certificate: %t\n"+
 					"  SSH Agent: %t\n"+
 					"  Checking Host Key: %t",
 				c.connInfo.BastionHost, c.connInfo.BastionUser,
 				c.connInfo.BastionPassword != "",
 				c.connInfo.BastionPrivateKey != "",
+				c.connInfo.BastionCertificate != "",
 				c.connInfo.Agent,
 				c.connInfo.BastionHostKey != "",
 			))

--- a/communicator/ssh/provisioner.go
+++ b/communicator/ssh/provisioner.go
@@ -53,12 +53,13 @@ type connectionInfo struct {
 	ScriptPath  string        `mapstructure:"script_path"`
 	TimeoutVal  time.Duration `mapstructure:"-"`
 
-	BastionUser       string `mapstructure:"bastion_user"`
-	BastionPassword   string `mapstructure:"bastion_password"`
-	BastionPrivateKey string `mapstructure:"bastion_private_key"`
-	BastionHost       string `mapstructure:"bastion_host"`
-	BastionHostKey    string `mapstructure:"bastion_host_key"`
-	BastionPort       int    `mapstructure:"bastion_port"`
+	BastionUser        string `mapstructure:"bastion_user"`
+	BastionPassword    string `mapstructure:"bastion_password"`
+	BastionPrivateKey  string `mapstructure:"bastion_private_key"`
+	BastionCertificate string `mapstructure:"bastion_certificate"`
+	BastionHost        string `mapstructure:"bastion_host"`
+	BastionHostKey     string `mapstructure:"bastion_host_key"`
+	BastionPort        int    `mapstructure:"bastion_port"`
 
 	AgentIdentity string `mapstructure:"agent_identity"`
 }
@@ -123,6 +124,9 @@ func parseConnectionInfo(s *terraform.InstanceState) (*connectionInfo, error) {
 		if connInfo.BastionPrivateKey == "" {
 			connInfo.BastionPrivateKey = connInfo.PrivateKey
 		}
+		if connInfo.BastionCertificate == "" {
+			connInfo.BastionCertificate = connInfo.Certificate
+		}
 		if connInfo.BastionPort == 0 {
 			connInfo.BastionPort = connInfo.Port
 		}
@@ -171,12 +175,13 @@ func prepareSSHConfig(connInfo *connectionInfo) (*sshConfig, error) {
 		bastionHost := fmt.Sprintf("%s:%d", connInfo.BastionHost, connInfo.BastionPort)
 
 		bastionConf, err = buildSSHClientConfig(sshClientConfigOpts{
-			user:       connInfo.BastionUser,
-			host:       bastionHost,
-			privateKey: connInfo.BastionPrivateKey,
-			password:   connInfo.BastionPassword,
-			hostKey:    connInfo.HostKey,
-			sshAgent:   sshAgent,
+			user:        connInfo.BastionUser,
+			host:        bastionHost,
+			privateKey:  connInfo.BastionPrivateKey,
+			password:    connInfo.BastionPassword,
+			hostKey:     connInfo.HostKey,
+			certificate: connInfo.BastionCertificate,
+			sshAgent:    sshAgent,
 		})
 		if err != nil {
 			return nil, err

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -291,6 +291,10 @@ var connectionBlockSupersetSchema = &configschema.Block{
 			Type:     cty.String,
 			Optional: true,
 		},
+		"bastion_certificate": {
+			Type:     cty.String,
+			Optional: true,
+		},
 
 		// For type=winrm only (enforced in winrm communicator)
 		"https": {

--- a/website/docs/provisioners/connection.html.markdown
+++ b/website/docs/provisioners/connection.html.markdown
@@ -126,3 +126,7 @@ The `ssh` connection also supports the following fields to facilitate connnectio
   host. These can be loaded from a file on disk using
   [the `file` function](/docs/configuration/functions/file.html).
   Defaults to the value of the `private_key` field.
+
+* `bastion_certificate` - The contents of a signed CA Certificate. The certificate argument
+  must be used in conjunction with a `bastion_private_key`. These can be loaded from
+  a file on disk using the [the `file` function](/docs/configuration/functions/file.html).


### PR DESCRIPTION
In our company, we are using Hashicorp Vault together with a Terraform for granting temporary credentials for developers and services. For example, for reasons, when you need to run Terraform in a container as a service you will need to give SSH access (password or RSA keys) for a short time (for deploying or redeploying) and then withdraw access. In the best practices - secrets, token or keys never should leave a place where was created. Ideally, the solution, in this case, will generate RSA pair on the service and sign the public key with the Vault SSH Secrets Engine. Using SSH connection by certificate access already implemented in 0.12.x version of Terraform, but miss a certificate method for connections via Bastion. This PR adds missing functionality into Terraform by new parameter - `bastion_certificate`.
A short example of how we using this functionality:
```hcl
resource "aws_instance" "vault" {
...
  connection {
    type        = "ssh"
    host        = self.private_ip
    port        = var.ec2_port
    user        = var.ec2_user
    agent       = false
    timeout     = "2m"
    private_key = file("~/.ssh/id_rsa")
    certificate = file("~/.ssh/id_rsa-cert.pub")

    bastion_host        = aws_instance.bastion.public_ip
    bastion_user        = var.bastion_user
    bastion_port        = var.bastion_port
    bastion_private_key = file("~/.ssh/id_rsa")
    bastion_certificate = file("~/.ssh/id_rsa-cert.pub")
  }
...
}
```